### PR TITLE
Corrige le dépassement du tab argv quand argc==2

### DIFF
--- a/chapitre-13/exemple-sigqueue-1.c
+++ b/chapitre-13/exemple-sigqueue-1.c
@@ -46,7 +46,7 @@ int main (int argc, char * argv [])
 			}
 			break;
 		case 2 : 
-			if (sscanf(argv[2], "%d", & pid) != 1)
+			if (sscanf(argv[1], "%d", & pid) != 1)
 				usage(argv[0]);
 			numero = -SIGTERM;
 			valeur.sival_int = 0;


### PR DESCRIPTION
Quand on utilise le programme sans arguments optionnels (c'est à dire juste le pid), ce dernier provoque un segmentation fault à cause d'un mauvais indice de tableau dans argv. La pull request est là pour corriger ça.